### PR TITLE
Wrap text quando em telas mobiles para melhor visualização de textões

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -117,3 +117,11 @@ div#sympla-widget-288555 {
 div#sympla-widget-288555 iframe {
   max-width: 600px !important;
 }
+
+@media all and (min-width 300px) and (max-width: 900px) {
+  table.responsive-table td {
+    max-width: 15em;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+}


### PR DESCRIPTION
Add: @media no arquivo de estilo para efetuar o wrap no texto nas tag TD das tabelas quando a tela estiver entre 300px e 900px